### PR TITLE
Remove aiofiles dependency by using asyncio instead

### DIFF
--- a/httpx_file/__init__.py
+++ b/httpx_file/__init__.py
@@ -1,7 +1,7 @@
+import asyncio
 from pathlib import Path
 from typing import Optional, Tuple
 
-import aiofiles
 import httpx
 
 __version__ = 0, 2, 0
@@ -101,8 +101,8 @@ class FileTransport(AsyncBaseTransport, BaseTransport):
             ospath = Path("/".join(parts))
 
             try:
-                async with aiofiles.open(ospath, mode="rb") as f:
-                    content = await f.read()
+                loop = asyncio.get_event_loop()
+                content = await loop.run_in_executor(None, ospath.read_bytes)
                 status = 200  # OK
             except FileNotFoundError:
                 status = 404  # Not Found

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ zip_safe = False
 python_requires = >= 3.6.1
 install_requires =
     httpx >= 0.20
-    aiofiles
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
This runs the synchronous `read_bytes()` operation in a thread pool, making it non-blocking. This change might have slightly different performance characteristics than using aiofiles, but nothing major. All tests are passing without modification.

There are currently two commits in this pr, which hopefully make it easier to review:
1. f6089b63dce4948542077d8725322700b842dcd8 which reformats the code
2. ee8359acc3773097b9760d6c8e3d72c1c247ecc7 which removes the dependency and makes the actual change

I needed to make this change to my fork as the dependent package is published on Conda forge, where `httpx_file` isn't available – removing the `aiofiles` dependency let me vendor it as a separate module, so I thought I'd give you the option of removing a dependency if you'd like.